### PR TITLE
Fixes this to work on 64bit systems to avoid this bug in Memcache itself...

### DIFF
--- a/classes/kohana/mcache.php
+++ b/classes/kohana/mcache.php
@@ -71,7 +71,7 @@ class Kohana_Mcache {
 	public function set(array $tables, $sql, $result, $lifetime)
 	{
 		$hash = $this->get_query_key($sql);
-		$this->cache->set($hash, $this->condense($result), $lifetime);
+		$this->cache->set($hash, $this->condense($result), 0, $lifetime);
 
 		foreach($tables as $table)
 		{


### PR DESCRIPTION
...: https://bugs.php.net/bug.php?id=59410/ ($flag needs to be set before $expire. See: http://www.php.net/manual/en/memcache.set.php)
